### PR TITLE
Fix deprecated calls in mixture_model

### DIFF
--- a/PythonCode/Chapter3/OutlierDetection.py
+++ b/PythonCode/Chapter3/OutlierDetection.py
@@ -53,12 +53,12 @@ class DistributionBasedOutlierDetection:
     def mixture_model(self, data_table, col):
         # Fit a mixture model to our data.
         data = data_table[data_table[col].notnull()][col]
-        g = mixture.GMM(n_components=3, n_iter=1)
+        g = mixture.GaussianMixture(n_components=3, max_iter=1)
 
-        g.fit(data.reshape(-1,1))
+        g.fit(data.values.reshape(-1,1))
 
         # Predict the probabilities
-        probs = g.score(data.reshape(-1,1))
+        probs = g.score(data.values.reshape(-1,1))
 
         # Create the right data frame and concatenate the two.
         data_probs = pd.DataFrame(np.power(10, probs), index=data.index, columns=[col+'_mixture'])


### PR DESCRIPTION
1. `sklearn.mixture.GMM` has been replaced with
   `sklearn.mixture.GaussianMixture`
   (https://scikit-learn.org/0.20/modules/generated/sklearn.mixture.GaussianMixture.html#sklearn.mixture.GaussianMixture).
2. `pandas.Series.reshape` has been deprecated in version 0.22, use
   `pandas.Series.values.reshape instead` (https://pandas.pydata.org/pandas-docs/version/0.22/generated/pandas.Series.reshape.html#pandas.Series.reshape).