### PR TITLE
Fix 'NonHierarchicalClustering' object has no attribute 'ranges' ch5

### DIFF
--- a/Python3Code/Chapter5/Clustering.py
+++ b/Python3Code/Chapter5/Clustering.py
@@ -145,7 +145,7 @@ class NonHierarchicalClustering:
         DM = InstanceDistanceMetrics()
 
         # Define the ranges of the columns if we use the gower distance.
-        ranges = []
+        self.ranges = []
         if distance_metric == self.gower:
             for col in dataset.columns:
                 self.ranges.append(dataset[col].max() - dataset[col].min())


### PR DESCRIPTION
In chapter 5 method `compute_distance_matrix_instances` the attribute `self.ranges`
is accessed but this is unset. The cause is that `ranges` above is set as variable
within the scope of the current method but since this is not the constructor of
the class it does not actually set `self.ranges`. This in turn causes the
subsequent access to result in an `AttributeError`.

This pull request resolves the aforementioned issues above.