### PR TITLE
Fix typos in Python3Code/README.md

### DIFF
--- a/Python3Code/README.md
+++ b/Python3Code/README.md
@@ -63,11 +63,11 @@ Also, in some cases one can add parameter settings as well through the argument 
 
 For example to solely run the LOF outlier detection method of Chapter3 with parameter-argument: K=4:
 ```bash
-python3 crowdsignals_ch_3_outliers.py --mode=”LOF” --K=4
+python3 crowdsignals_ch3_outliers.py --mode="LOF" --K=4
 ```
 And to finish chapter3-outliers, and move to chapter3-rest:
 ```bash
-python3 crowdsignals_ch3_outliers.py --mode=”final”
+python3 crowdsignals_ch3_outliers.py --mode=”final"
 ```
 
 

--- a/Python3Code/README.md
+++ b/Python3Code/README.md
@@ -67,7 +67,7 @@ python3 crowdsignals_ch3_outliers.py --mode="LOF" --K=4
 ```
 And to finish chapter3-outliers, and move to chapter3-rest:
 ```bash
-python3 crowdsignals_ch3_outliers.py --mode=”final"
+python3 crowdsignals_ch3_outliers.py --mode="final"
 ```
 
 


### PR DESCRIPTION
Changes crowdsignals_ch_3_outliers.py to crowdsignals_ch3_outliers.py in [Python3Code/README.md](https://github.com/mhoogen/ML4QS/blob/b6777bc757c9cc404cfd33c1103b5ae190d86bb2/Python3Code/README.md)
This naming would be consistent with "crowdsignals_ch2.py" mentioned earlier, e.g. no underscores between "ch" and the chapter number and the other files in the Python3Code directory.
Changes ” to ", not sure if this is OS specific? The original quotes on my computer running Pop_OS which is based on Ubuntu 20.04 using UTF-8 encoding in VS Code's terminal doesn't recognize these quotes (https://i.imgur.com/FAGJ9CY.png)