### PR TITLE
Outlier Detection bug

### DIFF
--- a/Python3Code/Chapter3/OutlierDetection.py
+++ b/Python3Code/Chapter3/OutlierDetection.py
@@ -23,14 +23,14 @@ class DistributionBasedOutlierDetection:
 
     # Finds outliers in the specified column of datatable and adds a binary column with
     # the same name extended with '_outlier' that expresses the result per data point.
-    def chauvenet(self, data_table, col):
+    def chauvenet(self, data_table, col, C):
         # Taken partly from: https://www.astro.rug.nl/software/kapteyn/
 
         # Computer the mean and standard deviation.
         mean = data_table[col].mean()
         std = data_table[col].std()
         N = len(data_table.index)
-        criterion = 1.0/(2*N)
+        criterion = 1.0/(C*N)
 
         # Consider the deviation for the data points.
         deviation = abs(data_table[col] - mean)/std

--- a/Python3Code/Chapter3/OutlierDetection.py
+++ b/Python3Code/Chapter3/OutlierDetection.py
@@ -112,7 +112,7 @@ class DistanceBasedOutlierDetection:
                                      'simple_dist_outlier'])
             data_table = pd.concat([data_table, data_mask], axis=1)
         else:
-            data_table['simple_dist_outlier'] = mask
+            data_table['simple_dist_outlier'] = pd.Series(mask, index=new_data_table.index)
         del self.distances
         return data_table
 
@@ -140,7 +140,7 @@ class DistanceBasedOutlierDetection:
                 outlier_factor, index=new_data_table.index, columns=['lof'])
             data_table = pd.concat([data_table, data_outlier_probs], axis=1)
         else:
-            data_table['lof'] = outlier_factor
+            data_table['lof'] = pd.Series(outlier_factor, index=new_data_table.index)
         del self.distances
         return data_table
 

--- a/Python3Code/Chapter3/OutlierDetection.py
+++ b/Python3Code/Chapter3/OutlierDetection.py
@@ -132,9 +132,12 @@ class DistanceBasedOutlierDetection:
         for i in range(0, len(new_data_table.index)):
             if i % 100 == 0: print(f'Completed {i} steps for LOF.')
             outlier_factor.append(self.local_outlier_factor_instance(i, k))
-        data_outlier_probs = pd.DataFrame(
-            outlier_factor, index=new_data_table.index, columns=['lof'])
-        data_table = pd.concat([data_table, data_outlier_probs], axis=1)
+        if data_table.get('lof') is None:
+            data_outlier_probs = pd.DataFrame(
+                outlier_factor, index=new_data_table.index, columns=['lof'])
+            data_table = pd.concat([data_table, data_outlier_probs], axis=1)
+        else:
+            data_table['lof'] = outlier_factor
         del self.distances
         return data_table
 

--- a/Python3Code/Chapter3/OutlierDetection.py
+++ b/Python3Code/Chapter3/OutlierDetection.py
@@ -36,8 +36,8 @@ class DistributionBasedOutlierDetection:
         deviation = abs(data_table[col] - mean)/std
 
         # Express the upper and lower bounds.
-        low = -deviation/math.sqrt(2)
-        high = deviation/math.sqrt(2)
+        low = -deviation/math.sqrt(C)
+        high = deviation/math.sqrt(C)
         prob = []
         mask = []
 

--- a/Python3Code/Chapter3/OutlierDetection.py
+++ b/Python3Code/Chapter3/OutlierDetection.py
@@ -107,9 +107,12 @@ class DistanceBasedOutlierDetection:
             ) if col_val > dmin]))/len(new_data_table.index))
             # Mark as an outlier if beyond the minimum frequency.
             mask.append(frac > fmin)
-        data_mask = pd.DataFrame(mask, index=new_data_table.index, columns=[
-                                 'simple_dist_outlier'])
-        data_table = pd.concat([data_table, data_mask], axis=1)
+        if data_table.get('simple_dist_outlier') is None:
+            data_mask = pd.DataFrame(mask, index=new_data_table.index, columns=[
+                                     'simple_dist_outlier'])
+            data_table = pd.concat([data_table, data_mask], axis=1)
+        else:
+            data_table['simple_dist_outlier'] = mask
         del self.distances
         return data_table
 

--- a/Python3Code/crowdsignals_ch3_outliers.py
+++ b/Python3Code/crowdsignals_ch3_outliers.py
@@ -130,16 +130,16 @@ if __name__ == '__main__':
                         'chauvenet' applies Chauvenet outlier detection method to a single variable \
                         'final' is used for the next chapter", choices=['LOF', 'distance', 'mixture', 'chauvenet', 'final'])
 
-    parser.add_argument('--C', type=int, default=2,
+    parser.add_argument('--C', type=float, default=2,
                         help="Chauvenet: C parameter")
    
     parser.add_argument('--K', type=int, default=5,
                         help="Local Outlier Factor:  K is the number of neighboring points considered")
 
-    parser.add_argument('--dmin', type=int, default=0.10,
+    parser.add_argument('--dmin', type=float, default=0.10,
                         help="Simple distance based:  dmin is ... ")
 
-    parser.add_argument('--fmin', type=int, default=0.99,
+    parser.add_argument('--fmin', type=float, default=0.99,
                         help="Simple distance based:  fmin is ... ")
 
     FLAGS, unparsed = parser.parse_known_args()

--- a/Python3Code/crowdsignals_ch3_outliers.py
+++ b/Python3Code/crowdsignals_ch3_outliers.py
@@ -65,7 +65,7 @@ def main():
 
             # And try out all different approaches. Note that we have done some optimization
             # of the parameter values for each of the approaches by visual inspection.
-            dataset = OutlierDistr.chauvenet(dataset, col)
+            dataset = OutlierDistr.chauvenet(dataset, col, FLAGS.C)
             DataViz.plot_binary_outliers(
                 dataset, col, col + '_outlier')
 
@@ -110,7 +110,7 @@ def main():
         for col in [c for c in dataset.columns if not 'label' in c]:
 
             print(f'Measurement is now: {col}')
-            dataset = OutlierDistr.chauvenet(dataset, col)
+            dataset = OutlierDistr.chauvenet(dataset, col, FLAGS.C)
             dataset.loc[dataset[f'{col}_outlier'] == True, col] = np.nan
             del dataset[col + '_outlier']
 
@@ -130,7 +130,8 @@ if __name__ == '__main__':
                         'chauvenet' applies Chauvenet outlier detection method to a single variable \
                         'final' is used for the next chapter", choices=['LOF', 'distance', 'mixture', 'chauvenet', 'final'])
 
-   
+    parser.add_argument('--C', type=int, default=2,
+                        help="Chauvenet: C parameter")
    
     parser.add_argument('--K', type=int, default=5,
                         help="Local Outlier Factor:  K is the number of neighboring points considered")


### PR DESCRIPTION
When running outlier detection in _LOF_ and _Distance_ modes over multiple columns, it accumulates several instances of "lof" or "distance" columns, making the dataset return 2D arrays which breaks plotting. I propose overwriting the column in case it exists.
Also, the code adds C parameter of Chauvenet's criterion, and fixes datatypes of parameters for Distance-based method.