### PR TITLE
Print warning if switching mpl backend fails

### DIFF
--- a/Python3Code/.gitignore
+++ b/Python3Code/.gitignore
@@ -1,0 +1,3 @@
+.cache
+figures
+intermediate_datafiles

--- a/Python3Code/util/VisualizeDataset.py
+++ b/Python3Code/util/VisualizeDataset.py
@@ -18,7 +18,10 @@ import sys
 from pathlib import Path
 import dateutil
 import matplotlib as mpl
-mpl.use('tkagg')
+try:
+    mpl.use('tkagg')
+except ImportError:
+    print('WARNING: Could not switch to TkAgg backend', file=sys.stderr)
 
 class VisualizeDataset:
 


### PR DESCRIPTION
Fixes the following bug (discovered while running in Docker container):
```python
Traceback (most recent call last):
  File "crowdsignals_ch2.py", line 12, in <module>
    from util.VisualizeDataset import VisualizeDataset
  File "/root/util/VisualizeDataset.py", line 21, in <module>
    mpl.use('tkagg')
  File "/usr/local/lib/python3.8/site-packages/matplotlib/cbook/deprecation.py", line 296, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/matplotlib/cbook/deprecation.py", line 358, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/matplotlib/__init__.py", line 1281, in use
    plt.switch_backend(name)
  File "/usr/local/lib/python3.8/site-packages/matplotlib/pyplot.py", line 234, in switch_backend
    raise ImportError(
ImportError: Cannot load backend 'TkAgg' which requires the 'tk' interactive framework, as 'headless' is currently running
```