### PR TITLE
Fix for `Segmentation Fault: 11` on the M1 MacBook

### DIFF
--- a/Python3Code/Chapter8/LearningAlgorithmsTemporal.py
+++ b/Python3Code/Chapter8/LearningAlgorithmsTemporal.py
@@ -7,6 +7,10 @@
 #                                                            #
 ##############################################################
 
+# Avoid `Segmentation Fault: 11` on M1 Mac
+import matplotlib as mpl
+mpl.use('tkagg')
+
 import pandas as pd
 import scipy.linalg
 import copy

--- a/Python3Code/ch3_visualization.py
+++ b/Python3Code/ch3_visualization.py
@@ -7,6 +7,10 @@
 #                                                            #
 ##############################################################
 
+# Avoid `Segmentation Fault: 11` on M1 Mac
+import matplotlib as mpl
+mpl.use('tkagg')
+
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt

--- a/Python3Code/ch4_visualization.py
+++ b/Python3Code/ch4_visualization.py
@@ -7,6 +7,10 @@
 #                                                            #
 ##############################################################
 
+# Avoid `Segmentation Fault: 11` on M1 Mac
+import matplotlib as mpl
+mpl.use('tkagg')
+
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt

--- a/Python3Code/ch5_visualization.py
+++ b/Python3Code/ch5_visualization.py
@@ -7,6 +7,10 @@
 #                                                            #
 ##############################################################
 
+# Avoid `Segmentation Fault: 11` on M1 Mac
+import matplotlib as mpl
+mpl.use('tkagg')
+
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt

--- a/Python3Code/ch6_visualization.py
+++ b/Python3Code/ch6_visualization.py
@@ -7,6 +7,10 @@
 #                                                            #
 ##############################################################
 
+# Avoid `Segmentation Fault: 11` on M1 Mac
+import matplotlib as mpl
+mpl.use('tkagg')
+
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plot

--- a/Python3Code/ch7_visualization.py
+++ b/Python3Code/ch7_visualization.py
@@ -7,6 +7,10 @@
 #                                                            #
 ##############################################################
 
+# Avoid `Segmentation Fault: 11` on M1 Mac
+import matplotlib as mpl
+mpl.use('tkagg')
+
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plot

--- a/Python3Code/ch8_visualization.py
+++ b/Python3Code/ch8_visualization.py
@@ -7,6 +7,10 @@
 #                                                            #
 ##############################################################
 
+# Avoid `Segmentation Fault: 11` on M1 Mac
+import matplotlib as mpl
+mpl.use('tkagg')
+
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plot


### PR DESCRIPTION
This branch addresses an issue that has been observed on the M1 MacBook.
When trying to display a Matplotlib figure without switching the backend to `'TkAgg'`, the program stops with `Segmentation Fault: 11`.

:warning: This is a very platform specific problem and the fix that this branch introduces has a lot of duplicate code. Maybe this it should not be merged, but left as a resource to users who encounter this bug. The underlying issue should be fixed in the library at some point in the future. :point_right: Draft only